### PR TITLE
feat: Add condition support to freeform mode for tuple addition

### DIFF
--- a/src/components/TuplesTab/TuplesTab.tsx
+++ b/src/components/TuplesTab/TuplesTab.tsx
@@ -72,6 +72,7 @@ export default function TuplesTab({ storeId, currentModel, authModelId }: Tuples
   const [freeformUser, setFreeformUser] = useState('');
   const [freeformRelation, setFreeformRelation] = useState('');
   const [freeformObject, setFreeformObject] = useState('');
+  const [freeformCondition, setFreeformCondition] = useState('');
   
   // Form state for assisted mode
   const [selectedType, setSelectedType] = useState('');
@@ -259,16 +260,30 @@ export default function TuplesTab({ storeId, currentModel, authModelId }: Tuples
       setNotification(null);
       setLoading(true);
 
-      await OpenFGAService.writeTuple(storeId, {
+      // Parse freeform condition if provided
+      let conditionData = null;
+      if (freeformCondition.trim()) {
+        try {
+          conditionData = JSON.parse(freeformCondition);
+        } catch (e) {
+          throw new Error('Invalid condition format. Please provide valid JSON.');
+        }
+      }
+
+      const tuple: RelationshipTuple = {
         user: freeformUser,
         relation: freeformRelation,
-        object: freeformObject
-      }, authModelId);
+        object: freeformObject,
+        ...(conditionData ? { condition: conditionData } : {})
+      };
+
+      await OpenFGAService.writeTuple(storeId, tuple, authModelId);
 
       // Reset form
       setFreeformUser('');
       setFreeformRelation('');
       setFreeformObject('');
+      setFreeformCondition('');
 
       // Reload tuples
       const response = await OpenFGAService.listTuples(storeId);
@@ -355,38 +370,58 @@ export default function TuplesTab({ storeId, currentModel, authModelId }: Tuples
               // Freeform mode
               <Box sx={{ 
                 display: 'flex', 
+                flexDirection: 'column',
                 gap: 2, 
                 alignItems: 'flex-start',
-                flexWrap: 'wrap',
                 width: '100%'
               }}>
-                <TextField
-                  size="small"
-                  sx={{ width: 250 }}
-                  label="User"
-                  value={freeformUser}
-                  onChange={(e) => setFreeformUser(e.target.value)}
-                  required
-                  helperText="Format: type:id or type#relation@id"
-                />
-                
-                <TextField
-                  size="small"
-                  sx={{ width: 250 }}
-                  label="Relation"
-                  value={freeformRelation}
-                  onChange={(e) => setFreeformRelation(e.target.value)}
-                  required
-                />
+                <Box sx={{ 
+                  display: 'flex', 
+                  gap: 2, 
+                  alignItems: 'flex-start',
+                  flexWrap: 'wrap',
+                  width: '100%'
+                }}>
+                  <TextField
+                    size="small"
+                    sx={{ width: 250 }}
+                    label="User"
+                    value={freeformUser}
+                    onChange={(e) => setFreeformUser(e.target.value)}
+                    required
+                    helperText="Format: type:id or type#relation@id"
+                  />
+                  
+                  <TextField
+                    size="small"
+                    sx={{ width: 250 }}
+                    label="Relation"
+                    value={freeformRelation}
+                    onChange={(e) => setFreeformRelation(e.target.value)}
+                    required
+                  />
+
+                  <TextField
+                    size="small"
+                    sx={{ width: 250 }}
+                    label="Object"
+                    value={freeformObject}
+                    onChange={(e) => setFreeformObject(e.target.value)}
+                    required
+                    helperText="Format: type:id"
+                  />
+                </Box>
 
                 <TextField
                   size="small"
-                  sx={{ width: 250 }}
-                  label="Object"
-                  value={freeformObject}
-                  onChange={(e) => setFreeformObject(e.target.value)}
-                  required
-                  helperText="Format: type:id"
+                  sx={{ width: '100%', maxWidth: 600 }}
+                  label="Condition (Optional)"
+                  value={freeformCondition}
+                  onChange={(e) => setFreeformCondition(e.target.value)}
+                  multiline
+                  rows={3}
+                  helperText='JSON format: {"name": "condition_name", "context": {"param1": "value1"}}'
+                  placeholder='{"name": "condition_name", "context": {"param1": "value1", "param2": "value2"}}'
                 />
 
                 <Button 


### PR DESCRIPTION
## Summary
Adds the ability to specify conditions when creating tuples in freeform mode. Previously, conditions were only available in assisted mode.

## Changes
- Added optional condition field to freeform mode interface
- Supports JSON input format with validation
- Maintains backward compatibility - condition field is optional
- Updated UI layout to accommodate new field with clear helper text

## Usage
Users can now add conditions in freeform mode using JSON format:
```json
{"name": "condition_name", "context": {"param1": "value1", "param2": "value2"}}
```


Fixes #3 where freeform mode lacked condition support compared to assisted mode.

